### PR TITLE
Use std::move to return local unique ptr

### DIFF
--- a/CCGS/sources/CCGSImplementation.cpp
+++ b/CCGS/sources/CCGSImplementation.cpp
@@ -971,7 +971,7 @@ L"true: #prec[999]1.0\r\n"
   if (!mAllowPassthrough)
     cgs->mTransform->stripPassthrough(aSourceModel);
 
-  return cgs;
+  return std::move(cgs);
 }
 
 CDA_CustomGenerator::CDA_CustomGenerator


### PR DESCRIPTION
Minor error. This line was causing my build to fail on Mac OS X (Clang). I added a std::move so that the smart pointer can be returned.

Cheers,
Kyle